### PR TITLE
Feat/cluster carousel logic

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  output: "standalone",
+  output: 'standalone',
   reactStrictMode: true,
-  swcMinify: true,
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,7 @@
 
 @font-face {
   font-family: 'Tiny5';
-  src:
-    url('/fonts/Tiny5/Tiny5-Regular.woff2') format('woff2'),
-    url('/fonts/Tiny5/Tiny5-Regular.ttf') format('truetype');
+  src: url('/fonts/Tiny5/Tiny5-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
   font-display: swap;

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,13 +1,11 @@
-"use client";
+'use client';
 
-import * as React from "react";
-import useEmblaCarousel, {
-  type UseEmblaCarouselType,
-} from "embla-carousel-react";
-import { ArrowLeft, ArrowRight } from "lucide-react";
-import Image from "next/image";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
@@ -17,7 +15,7 @@ type CarouselPlugin = UseCarouselParameters[1];
 type CarouselProps = {
   opts?: CarouselOptions;
   plugins?: CarouselPlugin;
-  orientation?: "horizontal" | "vertical";
+  orientation?: 'horizontal' | 'vertical';
   setApi?: (api: CarouselApi) => void;
 };
 
@@ -36,25 +34,25 @@ function useCarousel() {
   const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />");
+    throw new Error('useCarousel must be used within a <Carousel />');
   }
 
   return context;
 }
 
 function Carousel({
-  orientation = "horizontal",
+  orientation = 'horizontal',
   opts,
   setApi,
   plugins,
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & CarouselProps) {
+}: React.ComponentProps<'div'> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
     {
       ...opts,
-      axis: orientation === "horizontal" ? "x" : "y",
+      axis: orientation === 'horizontal' ? 'x' : 'y',
     },
     plugins
   );
@@ -77,10 +75,10 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      if (event.key === 'ArrowLeft') {
         event.preventDefault();
         scrollPrev();
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === 'ArrowRight') {
         event.preventDefault();
         scrollNext();
       }
@@ -96,11 +94,11 @@ function Carousel({
   React.useEffect(() => {
     if (!api) return;
     onSelect(api);
-    api.on("reInit", onSelect);
-    api.on("select", onSelect);
+    api.on('reInit', onSelect);
+    api.on('select', onSelect);
 
     return () => {
-      api?.off("select", onSelect);
+      api?.off('select', onSelect);
     };
   }, [api, onSelect]);
 
@@ -110,8 +108,7 @@ function Carousel({
         carouselRef,
         api: api,
         opts,
-        orientation:
-          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
         scrollPrev,
         scrollNext,
         canScrollPrev,
@@ -120,7 +117,7 @@ function Carousel({
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn("relative", className)}
+        className={cn('relative', className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
@@ -132,28 +129,20 @@ function Carousel({
   );
 }
 
-function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
   const { carouselRef, orientation } = useCarousel();
 
   return (
-    <div
-      ref={carouselRef}
-      className="overflow-hidden"
-      data-slot="carousel-content"
-    >
+    <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
       <div
-        className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
-        )}
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
         {...props}
       />
     </div>
   );
 }
 
-function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
   const { orientation } = useCarousel();
 
   return (
@@ -162,8 +151,8 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       aria-roledescription="slide"
       data-slot="carousel-item"
       className={cn(
-        "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
         className
       )}
       {...props}
@@ -173,8 +162,8 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
 
 function CarouselPrevious({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel();
@@ -185,10 +174,10 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
       disabled={!canScrollPrev}
@@ -203,8 +192,8 @@ function CarouselPrevious({
 
 function CarouselNext({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollNext, canScrollNext } = useCarousel();
@@ -215,10 +204,10 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
       disabled={!canScrollNext}
@@ -233,8 +222,8 @@ function CarouselNext({
 
 function CarouselPreviousPixel({
   className,
-  variant = "ghost",
-  size = "icon",
+  variant = 'ghost',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel();
@@ -245,13 +234,12 @@ function CarouselPreviousPixel({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full flex items-center justify-center",
-        orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full flex items-center justify-center',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
-      disabled={!canScrollPrev}
       onClick={scrollPrev}
       {...props}
     >
@@ -259,7 +247,7 @@ function CarouselPreviousPixel({
         alt="next"
         width={14}
         height={14}
-        src={"/assets/next.svg"}
+        src={'/assets/next.svg'}
         className="scale-x-[-1]"
       ></Image>
       <span className="sr-only">Previous slide</span>
@@ -269,8 +257,8 @@ function CarouselPreviousPixel({
 
 function CarouselNextPixel({
   className,
-  variant = "ghost",
-  size = "icon",
+  variant = 'ghost',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollNext, canScrollNext } = useCarousel();
@@ -281,17 +269,16 @@ function CarouselNextPixel({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full flex items-center justify-center",
-        orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full flex items-center justify-center',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
-      disabled={!canScrollNext}
       onClick={scrollNext}
       {...props}
     >
-      <Image alt="next" width={14} height={14} src={"/assets/next.svg"}></Image>
+      <Image alt="next" width={14} height={14} src={'/assets/next.svg'}></Image>
       <span className="sr-only">Next slide</span>
     </Button>
   );

--- a/src/features/clusters/containers/cluster-modal.tsx
+++ b/src/features/clusters/containers/cluster-modal.tsx
@@ -1,18 +1,13 @@
-"use client";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { useClusterModalStore } from "../store/useClusterModalStore";
-import CloseModal from "@/components/modal/close-modal";
-import Image from "next/image";
-import { useSelectClusterStore } from "@/store/useSelectClusterStore";
+'use client';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useClusterModalStore } from '../store/useClusterModalStore';
+import CloseModal from '@/components/modal/close-modal';
+import Image from 'next/image';
+import { useSelectClusterStore } from '@/store/useSelectClusterStore';
 
 export default function ClusterModal() {
   const { isOrgModalOpen, closeOrgModal } = useClusterModalStore();
-  const { setSelectedCluster } = useSelectClusterStore();
+  const { selectedCluster, setSelectedCluster } = useSelectClusterStore();
   return (
     <>
       <Dialog open={isOrgModalOpen} onOpenChange={closeOrgModal}>
@@ -30,13 +25,11 @@ export default function ClusterModal() {
                 {/* Clusters Title & Engage Card */}
                 <div className="flex flex-col gap-4">
                   <div className="flex flex-col gap-2">
-                    <h1 className="text-[clamp(1.5rem,4vw,1.875rem)]">
-                      Clusters!?
-                    </h1>
+                    <h1 className="text-[clamp(1.5rem,4vw,1.875rem)]">Clusters!?</h1>
                     <p className="font-space-mono text-[clamp(0.875rem,2.5vw,1rem)]">
-                      Clusters are alliances or groups of CSO-accredited
-                      organizations that share similar themes or goals. Select
-                      one that catches your eye, and find where you belong!
+                      Clusters are alliances or groups of CSO-accredited organizations that share
+                      similar themes or goals. Select one that catches your eye, and find where you
+                      belong!
                     </p>
                   </div>
                   <div>
@@ -44,7 +37,7 @@ export default function ClusterModal() {
                       className="w-full h-[200px] bg-[url('/bg/st-lasalle-bg.webp')] bg-center bg-cover bg-[#010F56]/70 hover:opacity-90 transition duration-100 bg-blend-multiply flex justify-start p-6 items-center rounded-lg text-white"
                       onClick={() => {
                         closeOrgModal();
-                        setSelectedCluster("engage");
+                        setSelectedCluster('engage');
                       }}
                     >
                       <div className="flex flex-col gap-2">
@@ -64,7 +57,7 @@ export default function ClusterModal() {
                     className="w-full h-full bg-[url('/bg/st-lasalle-bg.webp')] bg-center bg-cover bg-[#564C01]/70 hover:opacity-90 transition duration-100 bg-blend-multiply flex justify-start p-6 items-center rounded-lg text-white"
                     onClick={() => {
                       closeOrgModal();
-                      setSelectedCluster("cap13");
+                      setSelectedCluster('cap13');
                     }}
                   >
                     <button className="w-[85%] mx-auto flex flex-col gap-2">
@@ -97,15 +90,14 @@ export default function ClusterModal() {
                       className="flex flex-col gap-2"
                       onClick={() => {
                         closeOrgModal();
-                        setSelectedCluster("aspire");
+                        setSelectedCluster('aspire');
                       }}
                     >
                       <h1 className="text-left text-[clamp(1rem,2.5vw,1.5rem)] [text-shadow:_4px_4px_0px_rgba(0,0,0,1)]">
                         ASPIRE
                       </h1>
                       <p className="text-[clamp(0.65rem,1.5vw,1rem)] text-left font-space-mono font-bold leading-snug">
-                        College of Education and Special Interest and
-                        Socio-Civic Organizations
+                        College of Education and Special Interest and Socio-Civic Organizations
                       </p>
                     </button>
                   </div>
@@ -121,7 +113,7 @@ export default function ClusterModal() {
                   className="w-full h-full bg-[url('/bg/st-lasalle-bg.webp')] bg-center bg-cover bg-[#940000]/70 hover:opacity-90 transition duration-100  bg-blend-multiply flex justify-start items-center rounded-lg text-white"
                   onClick={() => {
                     closeOrgModal();
-                    setSelectedCluster("probe");
+                    setSelectedCluster('probe');
                   }}
                 >
                   <button className="w-[85%] mx-auto flex flex-col gap-2">
@@ -136,14 +128,14 @@ export default function ClusterModal() {
               </div>
               {/* ASO Card */}
               <div>
-                <div className="w-full h-full bg-[url('/bg/st-lasalle-bg.webp')] bg-center bg-cover bg-[#3FA300]/70 hover:opacity-90 transition duration-100  bg-blend-multiply flex justify-start p-6 items-center rounded-lg text-white">
-                  <button
-                    className="flex flex-col gap-2"
-                    onClick={() => {
-                      closeOrgModal();
-                      setSelectedCluster("aso");
-                    }}
-                  >
+                <div
+                  className="w-full h-full bg-[url('/bg/st-lasalle-bg.webp')] bg-center bg-cover bg-[#3FA300]/70 hover:opacity-90 transition duration-100  bg-blend-multiply flex justify-start p-6 items-center rounded-lg text-white"
+                  onClick={() => {
+                    closeOrgModal();
+                    setSelectedCluster('aso');
+                  }}
+                >
+                  <button className="flex flex-col gap-2">
                     <h1 className="text-left text-[clamp(1.25rem,4vw,1.875rem)] [text-shadow:_4px_4px_0px_rgba(0,0,0,1)]">
                       ASO
                     </h1>
@@ -158,9 +150,7 @@ export default function ClusterModal() {
             </section>
           </main>
           <footer className="flex justify-center">
-            <h3 className="font-tiny5 opacity-50">
-              Powered by La Salle Computer Society.
-            </h3>
+            <h3 className="font-tiny5 opacity-50">Powered by La Salle Computer Society.</h3>
           </footer>
         </DialogContent>
       </Dialog>

--- a/src/features/home/components/cluster-carousel.tsx
+++ b/src/features/home/components/cluster-carousel.tsx
@@ -1,0 +1,64 @@
+'use client';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPreviousPixel,
+  CarouselNextPixel,
+  type CarouselApi,
+} from '@/components/ui/carousel';
+import { useSelectClusterStore } from '@/store/useSelectClusterStore';
+import { clusters } from '../data/clusters';
+import { useCallback, useEffect, useRef } from 'react';
+
+export default function ClusterCarousel() {
+  const { selectedCluster, setSelectedCluster } = useSelectClusterStore();
+  const apiRef = useRef<CarouselApi | null>(null);
+
+  const handleApi = useCallback(
+    (api: CarouselApi) => {
+      if (!api) return;
+      apiRef.current = api;
+
+      const initialId = clusters[api.selectedScrollSnap()].id;
+      setSelectedCluster(initialId);
+
+      api.on('select', () => {
+        const index = api.selectedScrollSnap();
+        setSelectedCluster(clusters[index].id);
+      });
+    },
+    [selectedCluster]
+  );
+
+  useEffect(() => {
+    const api = apiRef.current;
+
+    if (!api) return;
+
+    const index = clusters.findIndex((cluster) => cluster.id === selectedCluster);
+
+    if (index >= 0 && index != api.selectedScrollSnap()) {
+      api.scrollTo(index);
+    }
+  }, [selectedCluster]);
+
+  return (
+    <>
+      <Carousel className="w-full my-4" opts={{ loop: true }} setApi={handleApi}>
+        <CarouselContent>
+          {clusters.map(({ id, acronym, name }, index) => {
+            return (
+              <CarouselItem key={index} className="pr-10 pl-14">
+                <h2 className="text-center text-blue-700 text-sm sm:text-2xl">{acronym}</h2>
+                <h4 className="text-center font-space-mono text-xs sm:text-lg">{name}</h4>
+              </CarouselItem>
+            );
+          })}
+        </CarouselContent>
+        <CarouselPreviousPixel className="left-1" />
+        <CarouselNextPixel className="right-1" />
+      </Carousel>
+    </>
+  );
+}

--- a/src/features/home/container/home-page.tsx
+++ b/src/features/home/container/home-page.tsx
@@ -2,25 +2,15 @@
 import HighlightCard from '@/components/highlight-card';
 import NavBar from '../components/navbar';
 import Image from 'next/image';
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselPreviousPixel,
-  CarouselNextPixel,
-} from '@/components/ui/carousel';
 import { Button } from '@/components/ui/button';
-import ExpandableText from '@/components/collapsible-text';
 import CollapsibleText from '@/components/collapsible-text';
 import { SearchBar } from '@/components/search-bar';
-import { useEffect, useState } from 'react';
 import ClusterModal from '@/features/clusters/containers/cluster-modal';
 import { useClusterModalStore } from '@/features/clusters/store/useClusterModalStore';
-import { clusters } from '../data/clusters';
+import ClusterCarousel from '../components/cluster-carousel';
 
 export default function HomePage() {
-  const [selectedCluster, setSelectedCluster] = useState('');
-  const { isOrgModalOpen, openOrgModal } = useClusterModalStore();
+  const { openOrgModal } = useClusterModalStore();
 
   return (
     <>
@@ -59,18 +49,7 @@ export default function HomePage() {
             </div>
           </HighlightCard>
 
-          <Carousel className="w-full my-4" opts={{ loop: true }}>
-            <CarouselContent>
-              {clusters.map(({ acronym, name }, index) => (
-                <CarouselItem key={index} className="pr-10 pl-14">
-                  <h2 className="text-center text-blue-700 text-sm sm:text-2xl">{acronym}</h2>
-                  <h4 className="text-center font-space-mono text-xs sm:text-lg">{name}</h4>
-                </CarouselItem>
-              ))}
-            </CarouselContent>
-            <CarouselPreviousPixel className="left-1" />
-            <CarouselNextPixel className="right-1" />
-          </Carousel>
+          <ClusterCarousel />
 
           <Button
             className="font-space-mono bg-[#D8E6FF] rounded-none border-black text-sm sm:text-base font-bold self-center mt-4 mb-8"

--- a/src/features/home/container/home-page.tsx
+++ b/src/features/home/container/home-page.tsx
@@ -1,36 +1,26 @@
-'use client'
-import HighlightCard from '@/components/highlight-card'
-import NavBar from '../components/navbar'
-import Image from 'next/image'
+'use client';
+import HighlightCard from '@/components/highlight-card';
+import NavBar from '../components/navbar';
+import Image from 'next/image';
 import {
   Carousel,
   CarouselContent,
   CarouselItem,
   CarouselPreviousPixel,
   CarouselNextPixel,
-} from '@/components/ui/carousel'
-import { Button } from '@/components/ui/button'
-import ExpandableText from '@/components/collapsible-text'
-import CollapsibleText from '@/components/collapsible-text'
-import { SearchBar } from '@/components/search-bar'
-import { useEffect, useState } from 'react'
-import ClusterModal from '@/features/clusters/containers/cluster-modal'
-import { useClusterModalStore } from '@/features/clusters/store/useClusterModalStore'
-
-const dummyData = [
-  {
-    acronym: 'All organizations',
-    name: 'All organizations among the 5 clusters in CSO.',
-  },
-  {
-    acronym: 'ENGAGE',
-    name: 'Engineering Alliance Geared Towards Excellence (ENGAGE).',
-  },
-]
+} from '@/components/ui/carousel';
+import { Button } from '@/components/ui/button';
+import ExpandableText from '@/components/collapsible-text';
+import CollapsibleText from '@/components/collapsible-text';
+import { SearchBar } from '@/components/search-bar';
+import { useEffect, useState } from 'react';
+import ClusterModal from '@/features/clusters/containers/cluster-modal';
+import { useClusterModalStore } from '@/features/clusters/store/useClusterModalStore';
+import { clusters } from '../data/clusters';
 
 export default function HomePage() {
-  const [selectedCluster, setSelectedCluster] = useState('')
-  const { isOrgModalOpen, openOrgModal } = useClusterModalStore()
+  const [selectedCluster, setSelectedCluster] = useState('');
+  const { isOrgModalOpen, openOrgModal } = useClusterModalStore();
 
   return (
     <>
@@ -69,16 +59,12 @@ export default function HomePage() {
             </div>
           </HighlightCard>
 
-          <Carousel className="w-full my-4">
+          <Carousel className="w-full my-4" opts={{ loop: true }}>
             <CarouselContent>
-              {dummyData.map(({ acronym, name }, index) => (
+              {clusters.map(({ acronym, name }, index) => (
                 <CarouselItem key={index} className="pr-10 pl-14">
-                  <h2 className="text-center text-blue-700 text-sm sm:text-2xl">
-                    {acronym}
-                  </h2>
-                  <h4 className="text-center font-space-mono text-xs sm:text-lg">
-                    {name}
-                  </h4>
+                  <h2 className="text-center text-blue-700 text-sm sm:text-2xl">{acronym}</h2>
+                  <h4 className="text-center font-space-mono text-xs sm:text-lg">{name}</h4>
                 </CarouselItem>
               ))}
             </CarouselContent>
@@ -99,5 +85,5 @@ export default function HomePage() {
         </div>
       </div>
     </>
-  )
+  );
 }

--- a/src/features/home/data/clusters.ts
+++ b/src/features/home/data/clusters.ts
@@ -1,10 +1,32 @@
 export const clusters = [
   {
+    id: 'all',
     acronym: 'All organizations',
     name: 'All organizations among the 5 clusters in CSO.',
   },
   {
+    id: 'engage',
     acronym: 'ENGAGE',
     name: 'Engineering Alliance Geared Towards Excellence (ENGAGE).',
+  },
+  {
+    id: 'cap13',
+    acronym: 'CAP 13',
+    name: 'College of Liberal Arts Organizations',
+  },
+  {
+    id: 'aspire',
+    acronym: 'ASPIRE',
+    name: 'College of Education and Special Interest and Socio-Civic Organizations',
+  },
+  {
+    id: 'probe',
+    acronym: 'PROBE',
+    name: 'Professional Organizations of Business and Economics',
+  },
+  {
+    id: 'aso',
+    acronym: 'ASO',
+    name: 'Alliance of Science Organizations',
   },
 ];

--- a/src/features/home/data/clusters.ts
+++ b/src/features/home/data/clusters.ts
@@ -1,0 +1,10 @@
+export const clusters = [
+  {
+    acronym: 'All organizations',
+    name: 'All organizations among the 5 clusters in CSO.',
+  },
+  {
+    acronym: 'ENGAGE',
+    name: 'Engineering Alliance Geared Towards Excellence (ENGAGE).',
+  },
+];


### PR DESCRIPTION
# Summary

Adds the ability to change clusters using a modal and makes the carousel loopable.


## Type of Change

    [x] feat: New feature

    [ ] fix: Bug fix

    [ ] docs: Documentation update

    [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

This pull request introduces two new features: the ability to change clusters via a modal and a loopable carousel. The first commit, b35b302, focuses on making the carousel component loopable, allowing users to endlessly cycle through items. The second commit, acb5a40, integrates a cluster modal that enables users to select and change the current cluster, which is then reflected in the carousel's content.

### Testing should focus on the following:

    Verifying that the carousel loops correctly and doesn't break when reaching the end of the items.

    Ensuring the cluster modal opens and closes as expected.

    Confirming that selecting a new cluster from the modal updates the carousel's content accurately.

    Checking for any unexpected side effects or bugs introduced by these changes.
