### PR TITLE
Feat/36 fetch initial orgs using isr

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -22,15 +22,15 @@ export async function POST() {
       return NextResponse.json({ error: 'Refresh failed' }, { status: 401 });
     }
 
-    // Extract new cookies from backend response
-    const setCookieHeaders = response.headers.getSetCookie();
+    // Extract Set-Cookie headers (string)
+    const setCookieHeader = response.headers.get('set-cookie');
 
     const nextResponse = NextResponse.json({ success: true });
 
-    // Forward the new cookies to the browser
-    setCookieHeaders.forEach((cookie) => {
-      nextResponse.headers.append('Set-Cookie', cookie);
-    });
+    if (setCookieHeader) {
+      // Forward the cookie to the client
+      nextResponse.headers.append('Set-Cookie', setCookieHeader);
+    }
 
     return nextResponse;
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import HomePage from '@/features/home/container/home-page';
 import { requireAuth } from '@/features/auth/services/server-auth';
 import { redirect } from 'next/navigation';
 import { getAllOrgs } from '@/features/orgs/services/orgs.services';
+import { OrgsResponse } from '@/features/orgs/types/orgs.types';
 
 export default async function Home() {
   const user = await requireAuth();
@@ -9,11 +10,11 @@ export default async function Home() {
   if (!user) redirect('/auth/login');
   if (user.needsRefresh) redirect('/auth/refresh');
 
-  const orgs = await getAllOrgs('', 0, 5);
+  const initialOrgs: OrgsResponse = await getAllOrgs('', 0, 5);
   return (
     <>
       <div className="min-h-screen p-8">
-        <HomePage user={user} initialOrgs={orgs} />
+        <HomePage user={user} initialOrgs={initialOrgs} />
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import HomePage from '@/features/home/container/home-page';
 import { requireAuth } from '@/features/auth/services/server-auth';
 import { redirect } from 'next/navigation';
+import { getAllOrgs } from '@/features/orgs/services/orgs.services';
 
 export default async function Home() {
   const user = await requireAuth();
@@ -8,6 +9,8 @@ export default async function Home() {
   if (!user) redirect('/auth/login');
   if (user.needsRefresh) redirect('/auth/refresh');
 
+  const orgs = await getAllOrgs('', 0, 10);
+  console.log(orgs);
   return (
     <>
       <div className="min-h-screen p-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,11 @@ export default async function Home() {
   if (!user) redirect('/auth/login');
   if (user.needsRefresh) redirect('/auth/refresh');
 
-  const orgs = await getAllOrgs('', 0, 10);
-  console.log(orgs);
+  const orgs = await getAllOrgs('', 0, 5);
   return (
     <>
       <div className="min-h-screen p-8">
-        <HomePage user={user} />
+        <HomePage user={user} initialOrgs={orgs} />
       </div>
     </>
   );

--- a/src/features/clusters/types/cluster.types.ts
+++ b/src/features/clusters/types/cluster.types.ts
@@ -1,0 +1,5 @@
+export type ClusterType = {
+  id: number;
+  name: string;
+  description: string;
+};

--- a/src/features/home/container/home-page.tsx
+++ b/src/features/home/container/home-page.tsx
@@ -11,12 +11,15 @@ import { SearchBar } from '@/components/search-bar';
 import ClusterModal from '@/features/clusters/containers/cluster-modal';
 import { useClusterModalStore } from '@/features/clusters/store/useClusterModalStore';
 import { User } from '@/features/auth/types/user';
+import OrgsContainer from '@/features/orgs/container/orgs-container';
+import { OrgsResponse } from '@/features/orgs/types/orgs.types';
 
 interface HomeProps {
   user: User;
+  initialOrgs: OrgsResponse;
 }
 
-export default function HomePage({ user }: HomeProps) {
+export default function HomePage({ user, initialOrgs }: HomeProps) {
   const { openOrgModal } = useClusterModalStore();
 
   return (
@@ -68,6 +71,7 @@ export default function HomePage({ user }: HomeProps) {
 
           <SearchBar />
           <ClusterModal />
+          <OrgsContainer orgs={initialOrgs.content} />
         </div>
       </div>
     </>

--- a/src/features/orgs/components/org-card.tsx
+++ b/src/features/orgs/components/org-card.tsx
@@ -1,51 +1,46 @@
-import { cn } from "@/lib/utils";
-import Image from "next/image";
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
+import { OrganizationType } from '../types/orgs.types';
 
 interface OrgCardProps {
   className?: string;
-  orgName: string;
-  desc: string;
-  orgLogo: string;
-  orgBg: string;
+  org: OrganizationType;
 }
 
-export default function OrgCard(props: OrgCardProps) {
+export default function OrgCard({ className, org }: OrgCardProps) {
   return (
     <>
       <div
         className={cn(
           `flex relative rounded-xl items-center w-full p-4 gap-2 bg-cover bg-center bg-black`,
-          props.className
+          className
         )}
-        style={{ backgroundImage: `url('${props.orgBg}')` }}
+        style={{ backgroundImage: `url('${org.publications.mainPubUrl}')` }}
       >
         <div
           className="w-full h-full absolute rounded-xl left-0"
           style={{
-            background:
-              "linear-gradient(to right, rgba(0,0,0,0.7), rgba(0,0,0,0.0))",
+            background: 'linear-gradient(to right, rgba(0,0,0,0.7), rgba(0,0,0,0.0))',
           }}
         />
 
         <div className="z-50 text-white flex flex-col gap-2 sm:flex-row items-center">
           <div className="flex items-center gap-2">
-            <Image
-              alt="org logo"
-              src={props.orgLogo || ""}
-              width={86}
-              height={86}
-              className="z-10"
-            ></Image>
-            <h3 className="sm:hidden block md:text-xl lg:text-2xl font-press-start">
-              {props.orgName}
-            </h3>
+            {/* {org.publications.logoUrl ? (
+              <Image
+                alt="org logo"
+                src={org.publications.logoUrl}
+                width={86}
+                height={86}
+                className="z-10"
+              />
+            ) : null} */}
+            <h3 className="sm:hidden block md:text-xl lg:text-2xl font-press-start">{org.name}</h3>
           </div>
 
           <span>
-            <h3 className="hidden sm:block md:text-xl lg:text-2xl font-press-start">
-              {props.orgName}
-            </h3>
-            <p className="font-tiny-5 lg:text-xl md:text-lg">{props.desc}</p>
+            <h3 className="hidden sm:block md:text-xl lg:text-2xl font-press-start">{org.name}</h3>
+            <p className="font-tiny-5 lg:text-xl md:text-lg">{org.about}</p>
           </span>
         </div>
       </div>

--- a/src/features/orgs/container/orgs-container.tsx
+++ b/src/features/orgs/container/orgs-container.tsx
@@ -1,0 +1,19 @@
+import OrgCard from '../components/org-card';
+import { OrganizationType } from '../types/orgs.types';
+
+type OrgsContainerProps = {
+  orgs: OrganizationType[];
+};
+
+export default function OrgsContainer({ orgs }: OrgsContainerProps) {
+  console.log(orgs);
+  return (
+    <>
+      <div className="flex flex-col gap-4 mt-8">
+        {orgs.map((org, index) => {
+          return <OrgCard key={index} org={org} />;
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/features/orgs/services/clusters.services.ts
+++ b/src/features/orgs/services/clusters.services.ts
@@ -1,19 +1,46 @@
-import api from '@/lib/axios';
+import { getCookieHeader } from '@/lib/auth-cookies';
+import axios from 'axios';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export async function getAllClusters() {
-  const { data } = await api.get('/clusters');
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/clusters`, {
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getAllClusters:', error);
+    throw error;
+  }
 }
 
 export async function getClusterByID(id: number) {
-  const { data } = await api.get(`/clusters/${id}`);
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/clusters/${id}`, {
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getClusterByID:', error);
+    throw error;
+  }
 }
 
 export async function getClusterByName(name: string) {
-  const { data } = await api.get(`/clusters/name/${name}`);
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/clusters/name/${name}`, {
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getClusterByName:', error);
+    throw error;
+  }
 }

--- a/src/features/orgs/services/orgs.services.ts
+++ b/src/features/orgs/services/orgs.services.ts
@@ -1,31 +1,66 @@
-import api from '@/lib/axios';
+import { getCookieHeader } from '@/lib/auth-cookies';
+import axios from 'axios';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export async function getAllOrgs(cluster?: string, page = 0, pageSize = 10) {
   const params: Record<string, string | number> = { page, pageSize };
-
   if (cluster) params.cluster = cluster;
 
-  const { data } = await api.get('/orgs', { params });
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/orgs`, {
+      params,
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getAllOrgs:', error);
+    throw error;
+  }
 }
 
 export async function getSearchOrg(q: string, page = 0, pageSize = 10) {
   const params: Record<string, string | number> = { q, page, pageSize };
+  const cookieHeader = await getCookieHeader();
 
-  const { data } = await api.get('/orgs/search', { params });
-
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/orgs/search`, {
+      params,
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getSearchOrg:', error);
+    throw error;
+  }
 }
 
 export async function getOrgByID(id: number) {
-  const { data } = await api.get(`/orgs/${id}`);
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/orgs/${id}`, {
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getOrgByID:', error);
+    throw error;
+  }
 }
 
 export async function getOrgByName(name: string) {
-  const { data } = await api.get(`/orgs/name/${name}`);
+  const cookieHeader = await getCookieHeader();
 
-  return data;
+  try {
+    const { data } = await axios.get(`${BASE_URL}/api/orgs/name/${name}`, {
+      headers: { cookie: cookieHeader },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error in getOrgByName:', error);
+    throw error;
+  }
 }

--- a/src/features/orgs/types/colleges.types.ts
+++ b/src/features/orgs/types/colleges.types.ts
@@ -1,0 +1,5 @@
+export type CollegeType = {
+  id: number;
+  name: string;
+  description: string;
+};

--- a/src/features/orgs/types/orgs.types.ts
+++ b/src/features/orgs/types/orgs.types.ts
@@ -1,0 +1,32 @@
+import { ClusterType } from '@/features/clusters/types/cluster.types';
+import { CollegeType } from './colleges.types';
+import { PublicationsType } from './pubs.types';
+
+export interface PageInfo {
+  size: number;
+  number: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface OrgsResponse {
+  content: OrganizationType[];
+  page: PageInfo;
+}
+
+export type OrganizationType = {
+  id: number;
+  name: string;
+  shortName: string;
+  about: string;
+  fee: number;
+  bundleFee: number;
+  gformsUrl: string;
+  facebookUrl: string;
+  mission: string;
+  vision: string;
+  tagline: string;
+  cluster: ClusterType;
+  college: CollegeType;
+  publications: PublicationsType;
+};

--- a/src/features/orgs/types/pubs.types.ts
+++ b/src/features/orgs/types/pubs.types.ts
@@ -1,0 +1,8 @@
+export type PublicationsType = {
+  id: number;
+  mainPubUrl: string;
+  feePubUrl: string;
+  logoUrl: string;
+  subLogoUrl: string;
+  orgVidUrl: string;
+};

--- a/src/lib/auth-cookies.ts
+++ b/src/lib/auth-cookies.ts
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers';
+
+export async function getCookieHeader(): Promise<string> {
+  const cookieStore = await cookies();
+  if (!cookieStore) return '';
+
+  const access = cookieStore.get('access_token')?.value;
+  const refresh = cookieStore.get('refresh_token')?.value;
+
+  const cookieHeader = [access && `access_token=${access}`, refresh && `refresh_token=${refresh}`]
+    .filter(Boolean)
+    .join('; ');
+
+  return cookieHeader;
+}


### PR DESCRIPTION
# Summary

Fetched and rendered organization cards using Incremental Static Regeneration (ISR). This change implements the initial display of organizations on the page, leveraging ISR for efficient data fetching and rendering.

## Linked Issues

closes #36 

## Type of Change

    [x] feat: New feature

    [ ] fix: Bug fix

    [ ] docs: Documentation update

    [ ] chore/refactor: Maintenance or code restructure

### Notes for Reviewers

Client-Side Rendering (CSR) with Tanstack will be implemented in a separate pull request. Please review the rendering of the organization cards and check the display of the image logos to ensure they are correct. Your feedback on these specific aspects is appreciated.