### PR TITLE
feat: uses color overlay for org card fallback

### DIFF
--- a/src/features/orgs/components/org-card.tsx
+++ b/src/features/orgs/components/org-card.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils';
 import { OrganizationType } from '../types/orgs.types';
+import { returnColorFromCluster } from '@/lib/helpers';
 
 interface OrgCardProps {
   className?: string;
@@ -11,10 +12,12 @@ export default function OrgCard({ className, org }: OrgCardProps) {
     <>
       <div
         className={cn(
-          `flex relative rounded-xl items-center w-full p-4 gap-2 bg-cover bg-center bg-black`,
+          `flex relative rounded-xl items-center w-full p-4 gap-2 bg-cover bg-center ${returnColorFromCluster(org.cluster.name.toLowerCase())}`,
           className
         )}
-        style={{ backgroundImage: `url('${org.publications.mainPubUrl}')` }}
+        style={{
+          backgroundImage: `url('${org.publications.mainPubUrl ?? '/bg/st-lasalle-bg.webp'}')`,
+        }}
       >
         <div
           className="w-full h-full absolute rounded-xl left-0"

--- a/src/features/orgs/container/orgs-container.tsx
+++ b/src/features/orgs/container/orgs-container.tsx
@@ -6,6 +6,7 @@ type OrgsContainerProps = {
 };
 
 export default function OrgsContainer({ orgs }: OrgsContainerProps) {
+  console.log(orgs);
   return (
     <>
       <div className="flex flex-col gap-4 mt-8">

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,14 @@
+export const returnColorFromCluster = (cluster: string) => {
+  switch (cluster) {
+    case 'engage':
+      return 'bg-[#010F56]/70';
+    case 'cap13':
+      return 'bg-[#564C01]/70';
+    case 'aspire':
+      return 'bg-[#8D0094]/70';
+    case 'probe':
+      return 'bg-[#940000]/70';
+    case 'aso':
+      return 'bg-[#3FA300]/70';
+  }
+};


### PR DESCRIPTION
# Summary

Adds a color overlay to the organization card fallback.

## Type of Change

    [x] feat: New feature

    [ ] fix: Bug fix

    [ ] docs: Documentation update

    [ ] chore/refactor: Maintenance or code restructure

### Notes for Reviewers

    A color overlay is now used for the fallback state of the organization card.

    Currently, each publication has a value, but it's not yet accessible or visible in the UI.  This data is present and can be utilized later.
